### PR TITLE
Remove crop on banner height

### DIFF
--- a/src/components/Banner/BannerImage/style.scss
+++ b/src/components/Banner/BannerImage/style.scss
@@ -1,6 +1,4 @@
 .BannerImage {
-  overflow-y: hidden;
-
   &__link {
     display: block;
     height: 100%;

--- a/src/components/Banner/style.scss
+++ b/src/components/Banner/style.scss
@@ -1,14 +1,7 @@
 @import "~vtex-css-utils/sass/_css-utils";
 
 .Banner {
-  height: 250px;
-  overflow-y: hidden;
-
   @media (max-width: $screen-xs-max) {
     padding: 0px;
-  }
-
-  @media (min-width: $screen-sm-max) {
-    height: 350px;
   }
 }


### PR DESCRIPTION
Banner looks really weird now because the current image is too tall — until we have an image upload with a crop feature (or some sort of image cropping on the backend), the user will need to upload a banner with the correct size.

💠*Needs Review* 💠
@tamorim @brenoc